### PR TITLE
'마이' 탭바의 마이페이지 UI 구현

### DIFF
--- a/YABAM/Feature/Sources/Views/Design/Components/ConfirmationPopup.swift
+++ b/YABAM/Feature/Sources/Views/Design/Components/ConfirmationPopup.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ConfirmationPopup: View {
+    let type: MyPagePopupType
+    @Binding var isPresented: Bool
+    let onConfirm: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+                .ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                Text(type == .logout ? "로그아웃 하시겠어요?" : "정말 회원탈퇴 하시겠어요?")
+                    .font(.headline)
+                    .padding()
+
+                HStack {
+                    Button("취소") {
+                        isPresented = false
+                    }
+                    .foregroundColor(.gray)
+
+                    Spacer()
+
+                    Button("확인") {
+                        onConfirm()
+                        isPresented = false
+                    }
+                    .foregroundColor(.red)
+                }
+                .padding(.horizontal)
+            }
+            .padding()
+            .background(Color.white)
+            .cornerRadius(12)
+            .shadow(radius: 10)
+            .frame(maxWidth: 300)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/Components/CouponButtonSection.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/Components/CouponButtonSection.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct CouponButtonSection: View {
+    var body: some View {
+        VStack {
+            Button(action: {
+                // 쿠폰 액션
+            }) {
+                HStack {
+                    YBText("쿠폰함", fontType: .mediumBody1, color: .Neutral.neutral900)
+                    Spacer()
+                    Image(systemName: "ticket")
+                        .foregroundColor(.gray)
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(12)
+            }
+        }
+        .padding(.horizontal)
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/Components/MenuListSection.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/Components/MenuListSection.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MenuListSection: View {
     var onItemTap: (MyPageRoute) -> Void
+    var onActionTap: (MyPagePopupType) -> Void
 
     var body: some View {
         VStack(spacing: 1) {
@@ -23,15 +24,18 @@ struct MenuListSection: View {
                 MyPageMenuItem(
                     title: "로그아웃",
                     isNavigable: false,
-                    color: .Neutral.neutral800,
-                    action: { }
-                )
+                    color: .Neutral.neutral800
+                ) {
+                    onActionTap(.logout)
+                }
+
                 MyPageMenuItem(
                     title: "회원탈퇴",
                     isNavigable: false,
-                    color: .Neutral.neutral600,
-                    action: { }
-                )
+                    color: .Neutral.neutral800
+                ) {
+                    onActionTap(.withdraw)
+                }
             }
         }
         .background(Color(.systemBackground))

--- a/YABAM/Feature/Sources/Views/MyPage/Components/MenuListSection.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/Components/MenuListSection.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct MenuListSection: View {
+    var onItemTap: (MyPageRoute) -> Void
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Group {
+                MyPageMenuItem(title: "닉네임 변경", isNavigable: true) {
+                    onItemTap(.editNickname)
+                }
+                MyPageMenuItem(title: "개인정보처리방침", isNavigable: true) {
+                    onItemTap(.privacyPolicy)
+                }
+                MyPageMenuItem(title: "이용약관", isNavigable: true) {
+                    onItemTap(.termsOfService)
+                }
+            }
+
+            YBDivider().padding(.vertical, 8)
+
+            Group {
+                MyPageMenuItem(
+                    title: "로그아웃",
+                    isNavigable: false,
+                    color: .Neutral.neutral800,
+                    action: { }
+                )
+                MyPageMenuItem(
+                    title: "회원탈퇴",
+                    isNavigable: false,
+                    color: .Neutral.neutral600,
+                    action: { }
+                )
+            }
+        }
+        .background(Color(.systemBackground))
+        .cornerRadius(12)
+        .padding(.horizontal)
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/Components/ProfileSection.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/Components/ProfileSection.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ProfileSection: View {
+    let nickname: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "person.crop.circle.fill")
+                .resizable()
+                .foregroundColor(.gray.opacity(0.6))
+                .frame(width: 80, height: 80)
+
+            YBText(nickname, fontType: .boldHeader4, color: .Neutral.neutral900)
+        }
+        .padding(.top, 40)
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MenuItemView/EditNicknameView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MenuItemView/EditNicknameView.swift
@@ -4,40 +4,38 @@ struct EditNicknameView: View {
     @Binding var nickname: String
     @State private var newNickname: String = ""
     @Environment(\.dismiss) private var dismiss
-
+    
     var body: some View {
-        NavigationView {
-            VStack(spacing: 20) {
-                TextField("새 닉네임을 입력하세요", text: $newNickname)
-                    .padding()
-                    .background(Color(.systemGray6))
-                    .cornerRadius(10)
-                    .padding(.horizontal)
-
-                Spacer()
-            }
-            .padding(.top, 32)
-            .navigationTitle("닉네임 변경")
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden()
-            .withNavigationButtons(
-                leading: NavigationButtonConfig {
-                    Image(.popArrow)
-                } action: {
+        VStack(spacing: 20) {
+            TextField("새 닉네임을 입력하세요", text: $newNickname)
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
+                .padding(.horizontal)
+            
+            Spacer()
+        }
+        .padding(.top, 32)
+        .navigationTitle("닉네임 변경")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
+        .withNavigationButtons(
+            leading: NavigationButtonConfig {
+                Image(.popArrow)
+            } action: {
+                dismiss()
+            },
+            trailing: NavigationButtonConfig {
+                YBText("저장", fontType: .boldBody1, color: newNickname.isEmpty ? .Neutral.neutral300 : .Neutral.neutral800)
+            } action: {
+                if !newNickname.isEmpty {
+                    nickname = newNickname
                     dismiss()
-                },
-                trailing: NavigationButtonConfig {
-                    YBText("저장", fontType: .boldBody1, color: newNickname.isEmpty ? .Neutral.neutral300 : .Neutral.neutral800)
-                } action: {
-                    if !newNickname.isEmpty {
-                        nickname = newNickname
-                        dismiss()
-                    }
                 }
-            )
-            .onAppear {
-                newNickname = nickname
             }
+        )
+        .onAppear {
+            newNickname = nickname
         }
     }
 }

--- a/YABAM/Feature/Sources/Views/MyPage/MenuItemView/EditNicknameView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MenuItemView/EditNicknameView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct EditNicknameView: View {
+    @Binding var nickname: String
+    @State private var newNickname: String = ""
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                TextField("새 닉네임을 입력하세요", text: $newNickname)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+
+                Spacer()
+            }
+            .padding(.top, 32)
+            .navigationTitle("닉네임 변경")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden()
+            .withNavigationButtons(
+                leading: NavigationButtonConfig {
+                    Image(.popArrow)
+                } action: {
+                    dismiss()
+                },
+                trailing: NavigationButtonConfig {
+                    YBText("저장", fontType: .boldBody1, color: newNickname.isEmpty ? .Neutral.neutral300 : .Neutral.neutral800)
+                } action: {
+                    if !newNickname.isEmpty {
+                        nickname = newNickname
+                        dismiss()
+                    }
+                }
+            )
+            .onAppear {
+                newNickname = nickname
+            }
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MenuItemView/PrivacyPolicyView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MenuItemView/PrivacyPolicyView.swift
@@ -58,7 +58,7 @@ struct PrivacyPolicyView: View {
 
                     section("8. 책임자 및 문의처", """
                     - 담당자: 개인정보 보호 책임자
-                    - 이메일: help@yabam.app
+                    - 이메일: gywns626@naver.com
                     - 문의 가능 시간: 평일 10:00 ~ 18:00
                     """)
                 }

--- a/YABAM/Feature/Sources/Views/MyPage/MenuItemView/PrivacyPolicyView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MenuItemView/PrivacyPolicyView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("개인정보 처리방침")
+                    .font(.title)
+                    .bold()
+                    .padding(.bottom, 8)
+
+                Group {
+                    section("1. 수집하는 개인정보 항목", """
+                    [1] 필수 수집 항목
+                    - 로그인 정보: 카카오 또는 애플 계정을 통한 사용자 인증 (고유 식별자, 이메일 등)
+                    - 디바이스 정보: 기기 모델, OS 버전, 앱 버전 등
+
+                    [2] 선택 수집 항목
+                    - 위치정보: 사용자 위치 기반으로 주변 가게 정보 제공
+                    - 카메라 접근 권한: QR코드를 통한 테이블 연결
+                    - 사진 라이브러리: 리뷰 작성 시 사진 업로드
+                    """)
+
+                    section("2. 개인정보 수집 및 이용 목적", """
+                    - 회원 인증 및 관리
+                    - 테이블 주문 기능 제공
+                    - 가게 정보 제공 (거리 표시 등)
+                    - 리뷰 작성 기능
+                    - 서비스 개선
+                    """)
+
+                    section("3. 개인정보 보유 및 이용기간", """
+                    - 회원 탈퇴 시 즉시 파기
+                    - 법령에 따라 보존이 필요한 경우는 해당 기간 동안 보관
+                    """)
+
+                    section("4. 개인정보 제3자 제공", """
+                    - 원칙적으로 외부 제공 없음
+                    - 단, 사용자 동의 또는 법령에 따라 제공될 수 있음
+                    """)
+
+                    section("5. 개인정보 처리 위탁", """
+                    - 현재 위탁 사항 없음
+                    - 향후 발생 시 사전 고지 및 동의 예정
+                    """)
+
+                    section("6. 사용자의 권리", """
+                    - 개인정보 열람, 수정, 삭제 요청 가능
+                    - 앱 내 설정 또는 고객센터를 통해 요청 가능
+                    """)
+
+                    section("7. 개인정보 보호 조치", """
+                    - 암호화 저장 및 최소 권한 접근
+                    - 보안 업데이트를 통한 보호
+                    """)
+
+                    section("8. 책임자 및 문의처", """
+                    - 담당자: 개인정보 보호 책임자
+                    - 이메일: help@yabam.app
+                    - 문의 가능 시간: 평일 10:00 ~ 18:00
+                    """)
+                }
+
+                Text("본 방침은 2025년 5월 8일부터 적용됩니다.")
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+                    .padding(.top, 20)
+            }
+            .padding()
+        }
+        .navigationTitle("개인정보처리방침")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
+        .withNavigationButtons(
+            leading: NavigationButtonConfig {
+                Image(.popArrow)
+            } action: {
+                dismiss()
+            }
+        )
+    }
+
+    private func section(_ title: String, _ content: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(content)
+                .font(.body)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MenuItemView/TermsOfServiceView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MenuItemView/TermsOfServiceView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct TermsOfServiceView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("이용약관")
+                    .font(.title)
+                    .bold()
+                    .padding(.bottom, 8)
+
+                Group {
+                    section("제1조 (목적)", """
+                    이 약관은 당사가 제공하는 위치기반 테이블 주문 서비스 및 가게 정보, 리뷰 기능 등의 서비스 이용에 관한 조건 및 절차, 이용자와 당사의 권리와 의무, 책임사항을 명확히 정함을 목적으로 합니다.
+                    """)
+
+                    section("제2조 (용어 정의)", """
+                    - "서비스": 당사가 제공하는 모든 앱 기능 및 부가 서비스
+                    - "이용자": 본 약관에 따라 당사의 서비스를 이용하는 자
+                    - "회원": 카카오 또는 애플 계정으로 로그인하여 서비스를 이용하는 자
+                    - "게스트": 로그인 없이 일부 기능만 이용하는 사용자
+                    """)
+
+                    section("제3조 (약관의 효력 및 변경)", """
+                    1. 본 약관은 앱을 통해 공지되며, 동의한 이용자에게 효력을 가집니다.
+                    2. 당사는 관련 법령을 위반하지 않는 범위 내에서 약관을 개정할 수 있습니다.
+                    3. 변경된 약관은 앱을 통해 공지되며, 계속 서비스를 이용할 경우 동의한 것으로 간주됩니다.
+                    """)
+
+                    section("제4조 (서비스의 제공 및 변경)", """
+                    1. 당사는 다음과 같은 서비스를 제공합니다:
+                       - 테이블 QR 주문 기능
+                       - 가게 정보 및 거리 안내
+                       - 사용자 리뷰 작성 및 열람
+                       - 사용자 계정 기반 개인화 기능
+
+                    2. 서비스 내용은 운영상, 기술상 필요에 따라 변경될 수 있으며, 사전에 앱 내 공지를 통해 안내합니다.
+                    """)
+
+                    section("제5조 (이용자의 의무)", """
+                    이용자는 다음 행위를 해서는 안 됩니다:
+                    - 타인의 정보를 도용하거나 부정 이용하는 행위
+                    - QR코드를 악의적으로 조작하는 행위
+                    - 리뷰 기능을 통한 비방, 허위 정보 작성
+                    - 위치정보를 악용하거나 변조하는 행위
+                    - 앱의 정상적인 운영을 방해하는 행위
+                    """)
+
+                    section("제6조 (개인정보 보호)", """
+                    당사는 개인정보 처리방침에 따라 이용자의 개인정보를 적법하게 보호합니다. 이용자는 개인정보 처리방침을 반드시 확인해야 합니다.
+                    """)
+
+                    section("제7조 (서비스의 중단)", """
+                    당사는 시스템 점검, 장애 또는 기타 불가피한 사유가 있는 경우 일시적으로 서비스를 중단할 수 있습니다. 이 경우 사전 또는 사후에 앱을 통해 안내합니다.
+                    """)
+
+                    section("제8조 (면책조항)", """
+                    - 당사는 천재지변, 네트워크 장애, 제3자의 고의적 공격 등 통제 불가능한 사유로 인한 손해에 대해 책임을 지지 않습니다.
+                    - 이용자의 귀책 사유로 인해 발생한 문제는 당사가 책임지지 않습니다.
+                    """)
+
+                    section("제9조 (준거법 및 관할)", """
+                    본 약관은 대한민국 법률에 따라 해석되며, 당사와 이용자 간 분쟁은 당사 소재지를 관할하는 법원의 전속관할로 합니다.
+                    """)
+                }
+
+                Text("본 약관은 2025년 5월 8일부터 적용됩니다.")
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+                    .padding(.top, 20)
+            }
+            .padding()
+        }
+        .navigationTitle("이용약관")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
+        .withNavigationButtons(
+            leading: NavigationButtonConfig {
+                Image(.popArrow)
+            } action: {
+                dismiss()
+            }
+        )
+    }
+
+    private func section(_ title: String, _ content: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(content)
+                .font(.body)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct MyPageMenuItem: View {
+    let title: String
+    var color: Color = .Neutral.neutral900
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                YBText(title, fontType: .mediumBody1, color: color)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.gray)
+            }
+            .padding(.vertical, 8)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
@@ -5,11 +5,14 @@ struct MyPageMenuItem: View {
     let isNavigable: Bool
     var color: Color = .Neutral.neutral900
     let action: () -> Void
-
+    
+    private var fontType: YBFont {
+        isNavigable ? .mediumBody1 : .mediumBody2
+    }
+    
     var body: some View {
         Button(action: action) {
             HStack {
-                let fontType: YBFont = isNavigable ? .mediumBody1 : .mediumBody2
                 YBText(title, fontType: fontType, color: color)
                 
                 Spacer()

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageMenuItem.swift
@@ -2,16 +2,22 @@ import SwiftUI
 
 struct MyPageMenuItem: View {
     let title: String
+    let isNavigable: Bool
     var color: Color = .Neutral.neutral900
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             HStack {
-                YBText(title, fontType: .mediumBody1, color: color)
+                let fontType: YBFont = isNavigable ? .mediumBody1 : .mediumBody2
+                YBText(title, fontType: fontType, color: color)
+                
                 Spacer()
-                Image(systemName: "chevron.right")
-                    .foregroundColor(.gray)
+                
+                if isNavigable {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.Neutral.neutral500)
+                }
             }
             .padding(.vertical, 8)
         }

--- a/YABAM/Feature/Sources/Views/MyPage/MyPagePopupType.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPagePopupType.swift
@@ -1,0 +1,4 @@
+enum MyPagePopupType {
+    case logout
+    case withdraw
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageRoute.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageRoute.swift
@@ -1,0 +1,5 @@
+enum MyPageRoute: Hashable {
+    case editNickname
+    case privacyPolicy
+    case termsOfService
+}

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -1,76 +1,46 @@
 import SwiftUI
 
+enum MyPageRoute: Hashable {
+    case editNickname
+    case privacyPolicy
+    case termsOfService
+}
+
 struct MyPageView: View {
     @State private var nickname: String = "사용자 닉네임"
-    @State private var showEditNicknameSheet: Bool = false
+    @State private var path: NavigationPath = NavigationPath()
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 32) {
-                // MARK: - 프로필 영역
-                VStack(spacing: 12) {
-                    Image(systemName: "person.crop.circle.fill")
-                        .resizable()
-                        .foregroundColor(.gray.opacity(0.6))
-                        .frame(width: 80, height: 80)
+        NavigationStack(path: $path) {
+            ScrollView {
+                VStack(spacing: 32) {
+                    ProfileSection(nickname: nickname)
 
-                    YBText(nickname, fontType: .boldHeader4, color: .Neutral.neutral900)
-                }
-                .padding(.top, 40)
+                    CouponButtonSection()
 
-                // MARK: - 쿠폰 버튼
-                VStack {
-                    Button(action: {
-                        // 쿠폰 액션
-                    }) {
-                        HStack {
-                            YBText("쿠폰함", fontType: .mediumBody1, color: .Neutral.neutral900)
-                            Spacer()
-                            Image(systemName: "ticket")
-                                .foregroundColor(.gray)
-                        }
-                        .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(12)
+                    MenuListSection { route in
+                        path.append(route)
                     }
                 }
-                .padding(.horizontal)
-
-                // MARK: - 메뉴 리스트
-                VStack(spacing: 1) {
-                    Group {
-                        MyPageMenuItem(title: "닉네임 변경") {
-                            showEditNicknameSheet = true
-                        }
-                        MyPageMenuItem(title: "개인정보처리방침") {}
-                        MyPageMenuItem(title: "이용약관") {}
-                    }
-
-                    YBDivider().padding(.vertical, 8)
-
-                    Group {
-                        MyPageMenuItem(title: "로그아웃") {}
-                        MyPageMenuItem(title: "회원탈퇴", color: .red) {}
-                    }
-                }
-                .background(Color(.systemBackground))
-                .cornerRadius(12)
-                .padding(.horizontal)
+                .padding(.bottom, 40)
             }
-            .padding(.bottom, 40)
+            .padding(.horizontal, 16)
+            .navigationDestination(for: MyPageRoute.self) { route in
+                switch route {
+                case .editNickname:
+                    EditNicknameView(nickname: $nickname)
+                case .privacyPolicy:
+                    EmptyView()
+                case .termsOfService:
+                    EmptyView()
+                }
+            }
+            .withNavigationButtons(
+                leading: NavigationButtonConfig(content: {
+                    Image(.yabamEmptyLogo).resizable().frame(width: 24, height: 24)
+                    YBText("마이페이지", fontType: .mediumHeader5, color: .Neutral.neutral900)
+                }, action: {})
+            )
         }
-        .padding(.horizontal, 16)
-        .navigationBarBackButtonHidden()
-        .navigationDestination(isPresented: $showEditNicknameSheet) {
-            EditNicknameView(nickname: $nickname)
-        }
-        .withNavigationButtons(
-            leading: NavigationButtonConfig(content: {
-                Image(.yabamEmptyLogo).resizable().frame(width: 24, height: 24)
-                YBText("마이페이지", fontType: .mediumHeader5, color: .Neutral.neutral900)
-            }, action: {
-                
-            })
-        )
     }
 }

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -27,7 +27,7 @@ struct MyPageView: View {
                 case .privacyPolicy:
                     PrivacyPolicyView()
                 case .termsOfService:
-                    EmptyView()
+                    TermsOfServiceView()
                 }
             }
             .withNavigationButtons(

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -3,22 +3,42 @@ import SwiftUI
 struct MyPageView: View {
     @State private var nickname: String = "사용자 닉네임"
     @State private var path: NavigationPath = NavigationPath()
-
+    @State private var activePopup: MyPagePopupType?
+    @State private var isPopupPresented = false
+    
     var body: some View {
         NavigationStack(path: $path) {
-            ScrollView {
-                VStack(spacing: 32) {
-                    ProfileSection(nickname: nickname)
+            ZStack {
+                ScrollView {
+                    VStack(spacing: 32) {
+                        ProfileSection(nickname: nickname)
 
-                    CouponButtonSection()
+                        CouponButtonSection()
 
-                    MenuListSection { route in
-                        path.append(route)
+                        MenuListSection(
+                            onItemTap: { route in
+                                path.append(route)
+                            },
+                            onActionTap: { popupType in
+                                activePopup = popupType
+                                isPopupPresented = true
+                            }
+                        )
                     }
+                    .padding(.bottom, 40)
                 }
-                .padding(.bottom, 40)
+                .padding(.horizontal, 16)
+
+                if let popup = activePopup, isPopupPresented {
+                    ConfirmationPopup(
+                        type: popup,
+                        isPresented: $isPopupPresented,
+                        onConfirm: {
+                            handlePopupAction(popup)
+                        }
+                    )
+                }
             }
-            .padding(.horizontal, 16)
             .navigationBarBackButtonHidden()
             .navigationDestination(for: MyPageRoute.self) { route in
                 switch route {
@@ -36,6 +56,15 @@ struct MyPageView: View {
                     YBText("마이페이지", fontType: .mediumHeader5, color: .Neutral.neutral900)
                 }, action: {})
             )
+        }
+    }
+
+    private func handlePopupAction(_ popup: MyPagePopupType) {
+        switch popup {
+        case .logout:
+            print("로그아웃 처리")
+        case .withdraw:
+            print("회원탈퇴 처리")
         }
     }
 }

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -1,11 +1,5 @@
 import SwiftUI
 
-enum MyPageRoute: Hashable {
-    case editNickname
-    case privacyPolicy
-    case termsOfService
-}
-
 struct MyPageView: View {
     @State private var nickname: String = "사용자 닉네임"
     @State private var path: NavigationPath = NavigationPath()
@@ -25,6 +19,7 @@ struct MyPageView: View {
                 .padding(.bottom, 40)
             }
             .padding(.horizontal, 16)
+            .navigationBarBackButtonHidden()
             .navigationDestination(for: MyPageRoute.self) { route in
                 switch route {
                 case .editNickname:

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -25,7 +25,7 @@ struct MyPageView: View {
                 case .editNickname:
                     EditNicknameView(nickname: $nickname)
                 case .privacyPolicy:
-                    EmptyView()
+                    PrivacyPolicyView()
                 case .termsOfService:
                     EmptyView()
                 }

--- a/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
+++ b/YABAM/Feature/Sources/Views/MyPage/MyPageView.swift
@@ -1,16 +1,69 @@
 import SwiftUI
 
 struct MyPageView: View {
+    @State private var nickname: String = "사용자 닉네임"
+    @State private var showEditNicknameSheet: Bool = false
+
     var body: some View {
-        VStack {
-            Spacer()
-            Text("👤 Profile View")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-            Spacer()
+        ScrollView {
+            VStack(spacing: 32) {
+                // MARK: - 프로필 영역
+                VStack(spacing: 12) {
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable()
+                        .foregroundColor(.gray.opacity(0.6))
+                        .frame(width: 80, height: 80)
+
+                    YBText(nickname, fontType: .boldHeader4, color: .Neutral.neutral900)
+                }
+                .padding(.top, 40)
+
+                // MARK: - 쿠폰 버튼
+                VStack {
+                    Button(action: {
+                        // 쿠폰 액션
+                    }) {
+                        HStack {
+                            YBText("쿠폰함", fontType: .mediumBody1, color: .Neutral.neutral900)
+                            Spacer()
+                            Image(systemName: "ticket")
+                                .foregroundColor(.gray)
+                        }
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(12)
+                    }
+                }
+                .padding(.horizontal)
+
+                // MARK: - 메뉴 리스트
+                VStack(spacing: 1) {
+                    Group {
+                        MyPageMenuItem(title: "닉네임 변경") {
+                            showEditNicknameSheet = true
+                        }
+                        MyPageMenuItem(title: "개인정보처리방침") {}
+                        MyPageMenuItem(title: "이용약관") {}
+                    }
+
+                    YBDivider().padding(.vertical, 8)
+
+                    Group {
+                        MyPageMenuItem(title: "로그아웃") {}
+                        MyPageMenuItem(title: "회원탈퇴", color: .red) {}
+                    }
+                }
+                .background(Color(.systemBackground))
+                .cornerRadius(12)
+                .padding(.horizontal)
+            }
+            .padding(.bottom, 40)
         }
-        .background(Color.green.opacity(0.1))
-        .edgesIgnoringSafeArea(.bottom)
+        .padding(.horizontal, 16)
+        .navigationBarBackButtonHidden()
+        .navigationDestination(isPresented: $showEditNicknameSheet) {
+            EditNicknameView(nickname: $nickname)
+        }
         .withNavigationButtons(
             leading: NavigationButtonConfig(content: {
                 Image(.yabamEmptyLogo).resizable().frame(width: 24, height: 24)

--- a/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryCardView.swift
+++ b/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryCardView.swift
@@ -5,7 +5,7 @@ struct OrderHistoryCardView: View {
     @State private var showReviewSheet = false
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             OrderHistoryHeaderView(date: order.orderDate) {
                 // 주문 상세 이동
             }
@@ -13,7 +13,7 @@ struct OrderHistoryCardView: View {
             OrderHistoryStoreSummaryView(
                 imageName: .yabamFillLogo,
                 storeName: order.storeName,
-                menuSummary: "\(order.orderedMenus.first?.name ?? "") 외 \(order.totalMenuCount)개 \(order.totalPrice)원"
+                menuSummary: "\(order.totalMenuCount)개 메뉴 주문 - 총 \(order.totalPrice)원"
             )
             
             OrderReviewButtonView(

--- a/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryReviewButtonView.swift
+++ b/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryReviewButtonView.swift
@@ -5,15 +5,20 @@ struct OrderReviewButtonView: View {
     let onTap: () -> Void
     
     var body: some View {
-        Button(action: onTap) {
-            YBText(canWriteReview ? "리뷰쓰기" : "리뷰수정",
-                   fontType: .boldBody1,
-                   color: .Neutral.neutral900)
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color(.systemGray6))
-            .cornerRadius(10)
+        if canWriteReview {
+            Button(action: onTap) {
+                YBText("리뷰 작성하기", fontType: .boldBody1, color: .white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.Semantic.info)
+                    .cornerRadius(10)
+            }
+        } else {
+            YBText("리뷰 작성완료", fontType: .boldBody1, color: .Neutral.neutral800)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
         }
-        .accessibilityLabel(canWriteReview ? "리뷰 작성하기" : "리뷰 수정하기")
     }
 }

--- a/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryStoreSummaryView.swift
+++ b/YABAM/Feature/Sources/Views/OrderHistory/Card/OrderHistoryStoreSummaryView.swift
@@ -7,7 +7,7 @@ struct OrderHistoryStoreSummaryView: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(imageName)
+            Image(imageName) // TODO: URL 이미지로 변경
                 .resizable()
                 .frame(width: 50, height: 50)
                 .cornerRadius(6)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #26 

<br>

## 📝 작업 내용
- 마이페이지 UI 구현
	- 닉네임변경/개인정보처리방침/이용약관 -> 네비게이션 Push/Pop
	- 로그아웃/회원탈퇴 -> 팝업 UI

<br>

## 📸 스크린샷
|마이페이지 메인|닉네임변경 Push|로그아웃 팝업|
|---|---|---|
|![Simulator Screenshot - iPhone 16 Pro - 2025-05-08 at 16 35 36](https://github.com/user-attachments/assets/00dee8da-f219-4d99-97e7-24c8454e3926)|![Simulator Screenshot - iPhone 16 Pro - 2025-05-08 at 16 35 50](https://github.com/user-attachments/assets/2c8c7cff-974b-45a6-8e13-759e3cd65c9a)|![Simulator Screenshot - iPhone 16 Pro - 2025-05-08 at 16 35 53](https://github.com/user-attachments/assets/b61430dd-3b1b-4b23-8a8d-6ca917231e0d)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 마이페이지에 프로필, 쿠폰함, 메뉴 리스트, 닉네임 변경, 개인정보처리방침, 이용약관, 로그아웃, 회원탈퇴 등 다양한 SwiftUI 컴포넌트가 추가되었습니다.
    - 닉네임 변경, 개인정보처리방침, 이용약관을 각각 별도의 화면에서 확인할 수 있습니다.
    - 로그아웃 및 회원탈퇴 시 확인 팝업이 표시됩니다.

- **기능 개선**
    - 주문내역 카드의 메뉴 요약 문구와 레이아웃이 개선되었습니다.
    - 리뷰 작성 버튼이 상태에 따라 버튼 또는 완료 텍스트로 구분되어 표시됩니다.

- **기타**
    - 일부 코드에 향후 이미지 URL 적용을 위한 주석이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->