### PR TITLE
OAuth 초기 설정 및 로그인 버튼에 Service 호출 액션 추가

### DIFF
--- a/YABAM/App/Project.swift
+++ b/YABAM/App/Project.swift
@@ -13,6 +13,7 @@ let appTarget = Target.target(
         .glob(pattern: .relativeToRoot("YABAM/App/Resources/**")),
         .glob(pattern: .relativeToRoot("YABAM/App/Resources/LaunchScreen.storyboard"))
     ],
+    entitlements: .file(path: .relativeToRoot("YABAM/App/SupportingFiles/yabam.entitlements")),
     dependencies: [
         // Module
         .core(),

--- a/YABAM/App/Resources/LaunchScreen.storyboard
+++ b/YABAM/App/Resources/LaunchScreen.storyboard
@@ -15,8 +15,19 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="authBackground" translatesAutoresizingMaskIntoConstraints="NO" id="sFW-9e-9A7">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                            </imageView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="sFW-9e-9A7" firstAttribute="trailing" secondItem="Bcu-3y-fUS" secondAttribute="trailing" id="9Ge-Ss-V1C"/>
+                            <constraint firstAttribute="bottom" secondItem="sFW-9e-9A7" secondAttribute="bottom" id="Tam-LA-mXP"/>
+                            <constraint firstItem="sFW-9e-9A7" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" id="cb4-ba-Wb4"/>
+                            <constraint firstItem="sFW-9e-9A7" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="gWK-ZM-Iy3"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -24,4 +35,7 @@
             <point key="canvasLocation" x="52.671755725190835" y="374.64788732394368"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="authBackground" width="633" height="1198"/>
+    </resources>
 </document>

--- a/YABAM/App/Resources/LaunchScreen.storyboard
+++ b/YABAM/App/Resources/LaunchScreen.storyboard
@@ -14,19 +14,41 @@
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="authBackground" translatesAutoresizingMaskIntoConstraints="NO" id="sFW-9e-9A7">
+                            <imageView contentMode="scaleAspectFill" image="authBackground" translatesAutoresizingMaskIntoConstraints="NO" id="sFW-9e-9A7">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="852" id="height-bg"/>
+                                    <constraint firstAttribute="width" constant="393" id="width-bg"/>
+                                </constraints>
                             </imageView>
+                            <stackView contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="OML-a9-tQh">
+                                <rect key="frame" x="116.66666666666669" y="318" width="160" height="216"/>
+                                <subviews>
+                                    <imageView contentMode="scaleAspectFit" image="YABAMWhiteLogo" translatesAutoresizingMaskIntoConstraints="NO" id="SKM-8C-eAF">
+                                        <rect key="frame" x="10" y="0.0" width="140" height="140"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="140" id="height-logo"/>
+                                            <constraint firstAttribute="width" constant="140" id="width-logo"/>
+                                        </constraints>
+                                    </imageView>
+                                    <imageView contentMode="scaleAspectFit" image="authYABAMText" translatesAutoresizingMaskIntoConstraints="NO" id="W9Y-ll-U0r">
+                                        <rect key="frame" x="0.0" y="156" width="160" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="height-text"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="sFW-9e-9A7" firstAttribute="trailing" secondItem="Bcu-3y-fUS" secondAttribute="trailing" id="9Ge-Ss-V1C"/>
-                            <constraint firstAttribute="bottom" secondItem="sFW-9e-9A7" secondAttribute="bottom" id="Tam-LA-mXP"/>
-                            <constraint firstItem="sFW-9e-9A7" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" id="cb4-ba-Wb4"/>
-                            <constraint firstItem="sFW-9e-9A7" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="gWK-ZM-Iy3"/>
+                            <constraint firstItem="sFW-9e-9A7" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="bg-leading"/>
+                            <constraint firstItem="sFW-9e-9A7" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="bg-top"/>
+                            <constraint firstItem="OML-a9-tQh" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="centerX"/>
+                            <constraint firstItem="OML-a9-tQh" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="centerY"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -36,6 +58,8 @@
         </scene>
     </scenes>
     <resources>
+        <image name="YABAMWhiteLogo" width="156" height="156.33332824707031"/>
         <image name="authBackground" width="633" height="1198"/>
+        <image name="authYABAMText" width="160" height="71.333335876464844"/>
     </resources>
 </document>

--- a/YABAM/App/Sources/AppDelegate.swift
+++ b/YABAM/App/Sources/AppDelegate.swift
@@ -1,16 +1,11 @@
 import UIKit
-import KakaoSDKCommon
 import Feature
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        if let kakaoAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String {
-            KakaoSDK.initSDK(appKey: kakaoAppKey)
-        }
-        
+    ) -> Bool {        
         FeatureFontFamily.registerAllCustomFonts()
         
         return true

--- a/YABAM/App/Sources/YABAMApp.swift
+++ b/YABAM/App/Sources/YABAMApp.swift
@@ -18,7 +18,7 @@ struct YABAMApp: App {
     
     var body: some Scene {
         WindowGroup {
-            AuthView()
+            RootView()
                 .onOpenURL(perform: { url in
                 if (AuthApi.isKakaoTalkLoginUrl(url)) {
                     _ = AuthController.handleOpenUrl(url: url)

--- a/YABAM/App/Sources/YABAMApp.swift
+++ b/YABAM/App/Sources/YABAMApp.swift
@@ -3,23 +3,27 @@ import Core
 import Feature
 import Network
 import KakaoSDKAuth
+import KakaoSDKCommon
 
 @main
 struct YABAMApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
-    init() {
+    init() {        
+        if let kakaoAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String {
+            KakaoSDK.initSDK(appKey: kakaoAppKey)
+        }
         setupDependencyInjection()
     }
     
     var body: some Scene {
         WindowGroup {
             AuthView()
-                .onOpenURL { url in
-                    if AuthApi.isKakaoTalkLoginUrl(url) {
-                        _ = AuthController.handleOpenUrl(url: url)
-                    }
+                .onOpenURL(perform: { url in
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
                 }
+            })
         }
     }
     

--- a/YABAM/App/Sources/YABAMApp.swift
+++ b/YABAM/App/Sources/YABAMApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Core
 import Feature
 import Network
+import KakaoSDKAuth
 
 @main
 struct YABAMApp: App {
@@ -14,6 +15,11 @@ struct YABAMApp: App {
     var body: some Scene {
         WindowGroup {
             AuthView()
+                .onOpenURL { url in
+                    if AuthApi.isKakaoTalkLoginUrl(url) {
+                        _ = AuthController.handleOpenUrl(url: url)
+                    }
+                }
         }
     }
     

--- a/YABAM/App/SupportingFiles/Info.plist
+++ b/YABAM/App/SupportingFiles/Info.plist
@@ -1,71 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>App</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleDisplayName</key>
-	<string>야 밤</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>1.0</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>테이블과 연결하기 위해 QR코드를 찍어야 하므로 카메라 권한 설정이 필요합니다.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>현재 위치를 사용하여 주변의 축제를 운영중인 가게 정보를 제공합니다.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진을 선택하고 공유하기 위해 사진 라이브러리에 접근이 필요합니다.</string>
-	<key>SERVER_URL</key>
-	<string>https://$(SERVER_URL)</string>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen.storyboard</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-</dict>
+    <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>$(DEVELOPMENT_LANGUAGE)</string>
+        <key>CFBundleExecutable</key>
+        <string>App</string>
+        <key>CFBundleIdentifier</key>
+        <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        <key>CFBundleDisplayName</key>
+        <string>야 밤</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>$(PRODUCT_NAME)</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Editor</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+                </array>
+            </dict>
+            <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Editor</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>kakao${KAKAO_NATIVE_APP_KEY}</string>
+                </array>
+            </dict>
+        </array>
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+            <string>kakaokompassauth</string>
+            <string>kakaolink</string>
+            <string>kakaoplus</string>
+        </array>
+        <key>LSRequiresIPhoneOS</key>
+        <true/>
+        <key>NSCameraUsageDescription</key>
+        <string>테이블과 연결하기 위해 QR코드를 찍어야 하므로 카메라 권한 설정이 필요합니다.</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>현재 위치를 사용하여 주변의 축제를 운영중인 가게 정보를 제공합니다.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>사진을 선택하고 공유하기 위해 사진 라이브러리에 접근이 필요합니다.</string>
+        <key>KAKAO_NATIVE_APP_KEY</key>
+        <string>$(KAKAO_NATIVE_APP_KEY)</string>
+        <key>SERVER_URL</key>
+        <string>https://$(SERVER_URL)</string>
+        <key>UIApplicationSceneManifest</key>
+        <dict>
+            <key>UIApplicationSupportsMultipleScenes</key>
+            <false/>
+            <key>UISceneConfigurations</key>
+            <dict>
+                <key>UIWindowSceneSessionRoleApplication</key>
+                <array>
+                    <dict>
+                        <key>UISceneConfigurationName</key>
+                        <string>Default Configuration</string>
+                        <key>UISceneDelegateClassName</key>
+                        <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+        <key>UILaunchStoryboardName</key>
+        <string>LaunchScreen.storyboard</string>
+        <key>UIRequiredDeviceCapabilities</key>
+        <array>
+            <string>armv7</string>
+        </array>
+        <key>UISupportedInterfaceOrientations</key>
+        <array>
+            <string>UIInterfaceOrientationPortrait</string>
+            <string>UIInterfaceOrientationPortraitUpsideDown</string>
+            <string>UIInterfaceOrientationLandscapeLeft</string>
+            <string>UIInterfaceOrientationLandscapeRight</string>
+        </array>
+    </dict>
 </plist>

--- a/YABAM/App/SupportingFiles/Info.plist
+++ b/YABAM/App/SupportingFiles/Info.plist
@@ -66,8 +66,6 @@
                     <dict>
                         <key>UISceneConfigurationName</key>
                         <string>Default Configuration</string>
-                        <key>UISceneDelegateClassName</key>
-                        <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
                     </dict>
                 </array>
             </dict>

--- a/YABAM/App/SupportingFiles/yabam.entitlements
+++ b/YABAM/App/SupportingFiles/yabam.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/YABAM/Core/Sources/YBError.swift
+++ b/YABAM/Core/Sources/YBError.swift
@@ -68,4 +68,8 @@ extension YBError: LocalizedError {
             return "예상치 못한 오류가 발생했습니다. 앱을 재시작해주세요."
         }
     }
+    
+    public var displayFeedbackMessage: String {
+        return self.recoverySuggestion ?? "다시 시도해주세요."
+    }
 }

--- a/YABAM/Feature/Sources/Views/Auth/AuthView.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthView.swift
@@ -1,18 +1,16 @@
 import SwiftUI
 import Network
 
-public struct AuthView: View {
+struct AuthView: View {
     @StateObject private var viewModel: AuthViewModel
     @State private var navigateToHome = false
     @State private var showErrorAlert = false
     
-    public init(
-        viewModel: @autoclosure @escaping () -> AuthViewModel = AuthViewModelFactory.make()
-    ) {
-        _viewModel = StateObject(wrappedValue: viewModel())
+    init(viewModel: AuthViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
-    public var body: some View {
+    var body: some View {
         ZStack {
             Image(.authBackground)
                 .resizable()
@@ -25,16 +23,7 @@ public struct AuthView: View {
             VStack {
                 Spacer()
 
-                VStack(spacing: 16) {
-                    Image(.yabamWhiteLogo)
-                        .resizable()
-                        .frame(width: 140, height: 140)
-
-                    Image(.authYABAMText)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(height: 60)
-                }
+                YBLogoView()
 
                 Spacer()
 

--- a/YABAM/Feature/Sources/Views/Auth/AuthView.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthView.swift
@@ -34,7 +34,7 @@ struct AuthView: View {
                     .disabled(viewModel.authState == .loading)
 
                     AppleLoginButtonView { oauthId, idToken in
-                        viewModel.handleAppleLogin(oauthId: oauthId, idToken: idToken)
+                        Task { await viewModel.handleAppleLogin(oauthId: oauthId, idToken: idToken) }
                     }
                     .disabled(viewModel.authState == .loading)
                 }

--- a/YABAM/Feature/Sources/Views/Auth/AuthView.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthView.swift
@@ -2,11 +2,15 @@ import SwiftUI
 import Network
 
 public struct AuthView: View {
-    @StateObject private var viewModel = AuthViewModel(authService: AuthService())
+    @StateObject private var viewModel: AuthViewModel
     @State private var navigateToHome = false
     @State private var showErrorAlert = false
     
-    public init() { }
+    public init(
+        viewModel: @autoclosure @escaping () -> AuthViewModel = AuthViewModelFactory.make()
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+    }
 
     public var body: some View {
         ZStack {

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
@@ -2,7 +2,7 @@ import Core
 import Combine
 import Network
 
-final class AuthViewModel: ObservableObject {
+public final class AuthViewModel: ObservableObject {
     enum AuthState: Equatable {
         case idle
         case loading

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
@@ -32,18 +32,16 @@ final class AuthViewModel: ObservableObject {
     }
     
     @MainActor
-    func handleAppleLogin(oauthId: String, idToken: String) {
-        Task {
-            authState = .loading
+    func handleAppleLogin(oauthId: String, idToken: String) async {
+        authState = .loading
 
-            do {
-                try await authService.loginWithApple(oauthId: oauthId, idToken: idToken)
-                authState = .authenticated
-            } catch let error as YBError {
-                authState = .failure(error.displayFeedbackMessage)
-            } catch {
-                authState = .failure("예기치 않은 오류가 발생했어요.")
-            }
+        do {
+            try await authService.loginWithApple(oauthId: oauthId, idToken: idToken)
+            authState = .authenticated
+        } catch let error as YBError {
+            authState = .failure(error.displayFeedbackMessage)
+        } catch {
+            authState = .failure("예기치 않은 오류가 발생했어요.")
         }
     }
 }

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
@@ -1,0 +1,49 @@
+import Core
+import Combine
+import Network
+
+final class AuthViewModel: ObservableObject {
+    enum AuthState: Equatable {
+        case idle
+        case loading
+        case authenticated
+        case failure(String)
+    }
+    
+    @Published var authState: AuthState = .idle
+    private let authService: AuthServiceInterface
+    
+    init(authService: AuthServiceInterface) {
+        self.authService = authService
+    }
+    
+    @MainActor
+    func handleKakaoLogin() async {
+        authState = .loading
+        
+        do {
+            try await authService.loginWithKakao()
+            authState = .authenticated
+        } catch let error as YBError {
+            authState = .failure(error.displayFeedbackMessage)
+        } catch {
+            authState = .failure("예기치 않은 오류가 발생했어요.")
+        }
+    }
+    
+    @MainActor
+    func handleAppleLogin(oauthId: String, idToken: String) {
+        Task {
+            authState = .loading
+
+            do {
+                try await authService.loginWithApple(oauthId: oauthId, idToken: idToken)
+                authState = .authenticated
+            } catch let error as YBError {
+                authState = .failure(error.displayFeedbackMessage)
+            } catch {
+                authState = .failure("예기치 않은 오류가 발생했어요.")
+            }
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModel.swift
@@ -2,7 +2,7 @@ import Core
 import Combine
 import Network
 
-public final class AuthViewModel: ObservableObject {
+final class AuthViewModel: ObservableObject {
     enum AuthState: Equatable {
         case idle
         case loading

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
@@ -3,7 +3,10 @@ import Core
 
 enum AuthViewModelFactory {
     static func make() -> AuthViewModel {
-        let service = try! DIContainer.shared.resolve(AuthServiceInterface.self)
+        guard let service = try? DIContainer.shared.resolve(AuthServiceInterface.self) else {
+            YBLogger.error("AuthService 의존성 주입 실패")
+            fatalError("AuthService 의존성 주입 실패")
+        }
         return AuthViewModel(authService: service)
     }
 }

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
@@ -1,0 +1,9 @@
+import Network
+import Core
+
+public enum AuthViewModelFactory {
+    public static func make() -> AuthViewModel {
+        let service = try! DIContainer.shared.resolve(AuthServiceInterface.self)
+        return AuthViewModel(authService: service)
+    }
+}

--- a/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
+++ b/YABAM/Feature/Sources/Views/Auth/AuthViewModelFactory.swift
@@ -1,8 +1,8 @@
 import Network
 import Core
 
-public enum AuthViewModelFactory {
-    public static func make() -> AuthViewModel {
+enum AuthViewModelFactory {
+    static func make() -> AuthViewModel {
         let service = try! DIContainer.shared.resolve(AuthServiceInterface.self)
         return AuthViewModel(authService: service)
     }

--- a/YABAM/Feature/Sources/Views/Common/RootView.swift
+++ b/YABAM/Feature/Sources/Views/Common/RootView.swift
@@ -21,6 +21,7 @@ public struct RootView: View {
                 try await YBTokenManager.shared.loadTokenFromKC()
                 isAuthenticated = true
             } catch {
+                YBLogger.error("토큰 로딩 실패: \(error.localizedDescription)")
                 isAuthenticated = false
             }
         }

--- a/YABAM/Feature/Sources/Views/Common/RootView.swift
+++ b/YABAM/Feature/Sources/Views/Common/RootView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import Core
+
+public struct RootView: View {
+    @State private var isAuthenticated: Bool? = nil
+    
+    public init() {}
+
+    public var body: some View {
+        Group {
+            if isAuthenticated == nil {
+                SplashView()
+            } else if isAuthenticated == true {
+                YBTabView()
+            } else {
+                AuthView(viewModel: AuthViewModelFactory.make())
+            }
+        }
+        .task {
+            do {
+                try await YBTokenManager.shared.loadTokenFromKC()
+                isAuthenticated = true
+            } catch {
+                isAuthenticated = false
+            }
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/Common/SplashView.swift
+++ b/YABAM/Feature/Sources/Views/Common/SplashView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+public struct SplashView: View {
+    public init() {}
+
+    public var body: some View {
+        ZStack {
+            Image(.authBackground)
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
+            Color.black.opacity(0.1)
+                .ignoresSafeArea()
+
+            YBLogoView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/Design/Components/YBLogoView.swift
+++ b/YABAM/Feature/Sources/Views/Design/Components/YBLogoView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+public struct YBLogoView: View {
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            Image(.yabamWhiteLogo)
+                .resizable()
+                .frame(width: 140, height: 140)
+
+            Image(.authYABAMText)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 60)
+        }
+    }
+}

--- a/YABAM/Feature/Sources/Views/MainTab/YBTabView.swift
+++ b/YABAM/Feature/Sources/Views/MainTab/YBTabView.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
-public struct YBTabView: View {
+struct YBTabView: View {
     @State private var selectedTab: Int = 0
     
-    public init() { }
-    
-    public var body: some View {
+    var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 ZStack {

--- a/YABAM/Network/Sources/Service/AuthService.swift
+++ b/YABAM/Network/Sources/Service/AuthService.swift
@@ -96,7 +96,7 @@ public struct AuthService: AuthServiceInterface {
     private func loginWithKakaoAccount() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
-                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
                     if let error = error {
                         continuation.resume(throwing: error)
                     } else if let idToken = oauthToken?.idToken {

--- a/YABAM/Network/Sources/Service/AuthService.swift
+++ b/YABAM/Network/Sources/Service/AuthService.swift
@@ -79,13 +79,15 @@ public struct AuthService: AuthServiceInterface {
 
     private func loginWithKakaoApp() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
-            UserApi.shared.loginWithKakaoTalk { oauthToken, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let idToken = oauthToken?.idToken {
-                    continuation.resume(returning: idToken)
-                } else {
-                    continuation.resume(throwing: YBError.oidcFailure)
+            Task { @MainActor in
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let idToken = oauthToken?.idToken {
+                        continuation.resume(returning: idToken)
+                    } else {
+                        continuation.resume(throwing: YBError.oidcFailure)
+                    }
                 }
             }
         }
@@ -93,13 +95,15 @@ public struct AuthService: AuthServiceInterface {
 
     private func loginWithKakaoAccount() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
-            UserApi.shared.loginWithKakaoAccount { oauthToken, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let idToken = oauthToken?.idToken {
-                    continuation.resume(returning: idToken)
-                } else {
-                    continuation.resume(throwing: YBError.oidcFailure)
+            Task { @MainActor in
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let idToken = oauthToken?.idToken {
+                        continuation.resume(returning: idToken)
+                    } else {
+                        continuation.resume(throwing: YBError.oidcFailure)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #34 

<br>

## 📝 작업 내용
- 카카오 로그인 초기 설정
	- @.main에서 카카오 init 등록
	- xcconfig 파일의 카카오 네이티브 앱 키 스킴 등록
- OAuth 버튼에 Service 호출 액션 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 앱에 Apple 로그인 기능이 추가되었습니다.
    - 스플래시 화면 및 인증 화면이 새롭게 디자인되었습니다.
    - 인증 상태에 따라 스플래시, 로그인, 메인 화면이 자동 전환됩니다.
    - 새로운 로고 컴포넌트(YBLogoView)가 도입되었습니다.

- **개선 및 변경**
    - 카카오 및 Apple 로그인 버튼 동작이 개선되었습니다.
    - 인증 실패 시 사용자에게 안내 메시지가 표시됩니다.
    - 인증 관련 뷰와 뷰모델 구조가 리팩토링되었습니다.
    - 앱 초기화 및 URL 핸들링 로직이 개선되어 카카오 SDK 연동이 강화되었습니다.

- **설정/문서**
    - Apple 로그인 및 카카오 연동을 위한 권한 및 URL 스킴이 추가되었습니다.
    - Info.plist 및 엔타이틀먼트 파일이 업데이트되었습니다.

- **버그 수정**
    - 인증 관련 비동기 처리에서 UI 스레드 안전성이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->