### PR TITLE
Firebase Analytics 등록 및 ScreenView Logging 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### macOS ###
 # Tuist 패키지 설치 관련 파일
 Tuist/Package.resolved
+GoogleService-Info.plist
 
 # General
 .DS_Store

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -20,5 +20,6 @@ let package = Package(
         .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.2"),
         .package(url: "https://github.com/kakao/kakao-ios-sdk.git", from: "2.23.0"),
         .package(url: "https://github.com/Kyxxn/SPM-KeyChainManager-KJ.git", from: "1.0.1"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+External.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+External.swift
@@ -5,6 +5,8 @@ public enum External: String {
     case CodeScanner
     case KakaoSDKAuth
     case KakaoSDKUser
+    case FirebaseAnalytics
+    case FirebaseCrashlytics
     case KeyChainManager = "KeyChainManager-KJ"
 }
 

--- a/YABAM/App/Project.swift
+++ b/YABAM/App/Project.swift
@@ -11,7 +11,6 @@ let appTarget = Target.target(
     sources: .sources,
     resources: [
         .glob(pattern: .relativeToRoot("YABAM/App/Resources/**")),
-        .glob(pattern: .relativeToRoot("YABAM/App/Resources/LaunchScreen.storyboard")),
         .glob(pattern: .relativeToRoot("YABAM/App/SupportingFiles/GoogleService-Info.plist"))
     ],
     entitlements: .file(path: .relativeToRoot("YABAM/App/SupportingFiles/yabam.entitlements")),

--- a/YABAM/App/Project.swift
+++ b/YABAM/App/Project.swift
@@ -11,7 +11,8 @@ let appTarget = Target.target(
     sources: .sources,
     resources: [
         .glob(pattern: .relativeToRoot("YABAM/App/Resources/**")),
-        .glob(pattern: .relativeToRoot("YABAM/App/Resources/LaunchScreen.storyboard"))
+        .glob(pattern: .relativeToRoot("YABAM/App/Resources/LaunchScreen.storyboard")),
+        .glob(pattern: .relativeToRoot("YABAM/App/SupportingFiles/GoogleService-Info.plist"))
     ],
     entitlements: .file(path: .relativeToRoot("YABAM/App/SupportingFiles/yabam.entitlements")),
     dependencies: [

--- a/YABAM/App/Sources/AppDelegate.swift
+++ b/YABAM/App/Sources/AppDelegate.swift
@@ -1,11 +1,13 @@
 import UIKit
 import Feature
+import FirebaseCore
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {        
+    ) -> Bool {
+        FirebaseApp.configure()
         FeatureFontFamily.registerAllCustomFonts()
         
         return true

--- a/YABAM/App/SupportingFiles/Info.plist
+++ b/YABAM/App/SupportingFiles/Info.plist
@@ -14,6 +14,8 @@
         <string>6.0</string>
         <key>CFBundleName</key>
         <string>$(PRODUCT_NAME)</string>
+        <key>CFBundleVersion</key>
+        <string>1.0.0</string>
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>
@@ -71,7 +73,7 @@
             </dict>
         </dict>
         <key>UILaunchStoryboardName</key>
-        <string>LaunchScreen.storyboard</string>
+        <string>LaunchScreen</string>
         <key>UIRequiredDeviceCapabilities</key>
         <array>
             <string>armv7</string>

--- a/YABAM/Feature/Project.swift
+++ b/YABAM/Feature/Project.swift
@@ -16,6 +16,7 @@ let project = Project(
                 .network(),
                 
                 // Third Party Library
+                .external(dependency: .FirebaseAnalytics),
                 .external(dependency: .CodeScanner)
             ]
         )

--- a/YABAM/Feature/Sources/Views/Home/HomeView.swift
+++ b/YABAM/Feature/Sources/Views/Home/HomeView.swift
@@ -4,6 +4,7 @@ struct HomeView: View {
     var body: some View {
         VStack {
             StoreListView(stores: StoreSampleData.storeList)
+                .logScreenStay(screen: .storeList)
         }
         .withNavigationButtons(
             leading: NavigationButtonConfig(content: {

--- a/YABAM/Feature/Sources/Views/Home/Store/Detail/StoreDetailTab.swift
+++ b/YABAM/Feature/Sources/Views/Home/Store/Detail/StoreDetailTab.swift
@@ -1,4 +1,4 @@
-enum StoreDetailTab: CaseIterable {
+enum StoreDetailTab: String, CaseIterable {
     case info, menu, review, location
 
     var title: String {

--- a/YABAM/Feature/Sources/Views/Home/Store/Detail/StoreDetailView.swift
+++ b/YABAM/Feature/Sources/Views/Home/Store/Detail/StoreDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FirebaseAnalytics
 
 struct StoreDetailView: View {
     let store: Store
@@ -8,6 +9,7 @@ struct StoreDetailView: View {
     @State private var selectedTab: StoreDetailTab = .info
     @State private var isImageFullscreenPresented = false
     @State private var selectedImageIndex = 0
+    @State private var tabEnterTime: Date?
     
     var body: some View {
         ScrollView {
@@ -42,6 +44,31 @@ struct StoreDetailView: View {
                 }
                 .padding(.top, 8)
             }
+        }
+        .onAppear {
+            Analytics.logEvent("screen_view", parameters: [
+                "screen_name": "store_detail",
+                "store_id": store.id,
+                "store_name": store.name
+            ])
+            tabEnterTime = Date()
+        }
+        .onChange(of: selectedTab) { newTab in
+            if let enterTime = tabEnterTime {
+                let duration = Date().timeIntervalSince(enterTime)
+                Analytics.logEvent("store_detail_tab_duration", parameters: [
+                    "tab": newTab.rawValue,
+                    "duration_sec": duration,
+                    "store_id": store.id
+                ])
+            }
+            
+            Analytics.logEvent("store_detail_tab_changed", parameters: [
+                "tab": newTab.rawValue,
+                "store_id": store.id
+            ])
+            
+            tabEnterTime = Date() // 새로운 탭 체류 시작 시간 갱신
         }
         .fullScreenCover(isPresented: $isImageFullscreenPresented) {
             YBFullscreenImageViewer(

--- a/YABAM/Feature/Sources/Views/Home/Store/StoreListView.swift
+++ b/YABAM/Feature/Sources/Views/Home/Store/StoreListView.swift
@@ -12,6 +12,7 @@ struct StoreListView: View {
                         NavigationLink(destination: StoreDetailView(store: store)) {
                             StoreRowView(store: store, userLocation: locationManager.userLocation)
                                 .padding(.horizontal)
+                            
                         }
                     }
                 }

--- a/YABAM/Feature/Sources/Views/MainTab/YBTabView.swift
+++ b/YABAM/Feature/Sources/Views/MainTab/YBTabView.swift
@@ -8,10 +8,10 @@ struct YBTabView: View {
             VStack(spacing: 0) {
                 ZStack {
                     switch selectedTab {
-                    case 0: HomeView()
-                    case 1: OrderQRCodeView()
-                    case 2: OrderHistoryView()
-                    case 3: MyPageView()
+                    case 0: HomeView().logScreenStay(screen: .home)
+                    case 1: OrderQRCodeView().logScreenStay(screen: .orderQRCode)
+                    case 2: OrderHistoryView().logScreenStay(screen: .orderHistory)
+                    case 3: MyPageView().logScreenStay(screen: .myPage)
                     default: HomeView()
                     }
                 }

--- a/YABAM/Feature/Sources/Views/Modifiers/View+logScreenStay.swift
+++ b/YABAM/Feature/Sources/Views/Modifiers/View+logScreenStay.swift
@@ -19,6 +19,7 @@ enum YBScreen: String {
     case cart
     case reviewWrite
     case orderHistory
+    case callStaffPopup
     case myPage
 }
 

--- a/YABAM/Feature/Sources/Views/Modifiers/View+logScreenStay.swift
+++ b/YABAM/Feature/Sources/Views/Modifiers/View+logScreenStay.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import FirebaseAnalytics
+
+extension View {
+    func logScreenStay(screen: YBScreen) -> some View {
+        self.modifier(ScreenStayLogger(screen: screen))
+    }
+}
+
+enum YBScreen: String {
+    case splash
+    case auth
+    case home
+    case storeList
+    case storeDetail
+    case orderQRCode
+    case menuOrder
+    case menuDetail
+    case cart
+    case reviewWrite
+    case orderHistory
+    case myPage
+}
+
+struct ScreenStayLogger: ViewModifier {
+    let screen: YBScreen
+    @State private var enterDate: Date?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                enterDate = Date()
+                Analytics.logEvent("screen_view", parameters: [
+                    "screen_name": screen.rawValue
+                ])
+            }
+            .onDisappear {
+                if let enterDate {
+                    let duration = Date().timeIntervalSince(enterDate)
+                    Analytics.logEvent("screen_stay_duration", parameters: [
+                        "screen_name": screen.rawValue,
+                        "duration_sec": duration
+                    ])
+                }
+            }
+    }
+}

--- a/YABAM/Feature/Sources/Views/Order/TableOrder/MenuOrder/MenuOrderView.swift
+++ b/YABAM/Feature/Sources/Views/Order/TableOrder/MenuOrder/MenuOrderView.swift
@@ -58,7 +58,7 @@ struct MenuOrderView: View {
             }
             
             if isCallStaffPopup {
-                CallStaffPopup(showPopup: $isCallStaffPopup)
+                CallStaffPopup(showPopup: $isCallStaffPopup).logScreenStay(screen: .callStaffPopup)
             }
         }
         .navigationTitle("메뉴 주문하기")
@@ -91,6 +91,7 @@ struct MenuOrderView: View {
         }
         .navigationDestination(isPresented: $isNavigatingToCart) {
             MenuCartView(cartManager: cartManager)
+                .logScreenStay(screen: .cart)
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #38 

<br>

## 📝 작업 내용
- Firebase Analytics 의존성 추가
- ScreenView Logging 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
    - Firebase Analytics 및 Crashlytics가 앱에 통합되어 화면 진입, 체류 시간, 탭 변경 등 사용자 활동이 자동으로 기록됩니다.
    - 주요 화면(Home, StoreList, StoreDetail, OrderQRCode, OrderHistory, MyPage 등)과 팝업, 장바구니 등에서 화면 체류 시간 로그가 추가되었습니다.

- **버그 수정**
    - 앱 버전 정보 및 런치 스토리보드 참조가 Info.plist에 반영되었습니다.

- **기타**
    - GoogleService-Info.plist 파일이 리소스에 추가되고, Git 추적에서 제외됩니다.
    - 외부 라이브러리 의존성(Firebase 관련)이 프로젝트에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->